### PR TITLE
Improve resolve params

### DIFF
--- a/.changeset/dirty-cycles-love.md
+++ b/.changeset/dirty-cycles-love.md
@@ -1,0 +1,22 @@
+---
+"@wbe/low-router": minor
+---
+
+## breaking change: Improve `resolve` and `onResolve` params.
+
+`router.resolve()` and `onResolve()` option return now `{response, context}` object of the matching route.
+
+before:
+```js
+router.resolve("/").then((res) => {
+  // res: "Hello home!"
+});
+```
+after:
+```js
+router.resolve("/").then(({ response, context }) => {
+  // response: "Hello home!"
+  // context: RouteContext interface
+});
+```
+

--- a/README.md
+++ b/README.md
@@ -83,18 +83,18 @@ const router = new LowRouter(routes);
 
 ### resolve
 
-The `resolve` method allows you to match a given pathname or route object to a defined route and execute its associated action. It returns a Promise that resolves with the action result.
+The `resolve` method allows you to match a given pathname or route object to a defined route and execute its associated action. It returns a Promise that resolves with the action result and route context.
 
 ```js
-router.resolve("/").then((res) => {
-  // res: "Hello home!"
+router.resolve("/").then(({ response, context }) => {
+  // response: "Hello home!"
 });
 ```
 
 Or, with an object param:
 ```js
-router.resolve({ name: "user", params: { id: 123 } }).then(res => {
-  // res: "Hello user! with id 123"
+router.resolve({ name: "user", params: { id: 123 } }).then(({ response, context }) => {
+  // response: "Hello user! with id 123"
 })
 ```
 
@@ -224,8 +224,8 @@ const options: Options = {
   onError: (context, error) => {},
   
   // called after a route's action has been executed successfully
-  // onResolve: (context: RouteContext<A, P>, actionResponse: ActionResponse<A>) => void
-  onResolve: (context, response) => {},
+  // onResolve: ({response: ActionResponse<A>, context: RouteContext<A, P>}) => void
+  onResolve: ({ response, context }) => {},
   
   // called when the router is disposed of using the `dispose` method
   // onDispose: () => void

--- a/examples/basic/src/index.ts
+++ b/examples/basic/src/index.ts
@@ -45,6 +45,6 @@ for (let link of links) {
   link.addEventListener("click", (e) => {
     e.preventDefault()
     const href = link.getAttribute("href")
-    router.resolve(href!).then((res) => console.log(href, "done"))
+    router.resolve(href!).then(({ response, context }) => console.log(href, "done"))
   })
 }

--- a/examples/compose/src/components/App.ts
+++ b/examples/compose/src/components/App.ts
@@ -59,7 +59,7 @@ export class App {
       {
         base: "/",
         debug: true,
-        onResolve: (ctx) => this.onRouteResolve(ctx),
+        onResolve: ({ response, context }) => this.onRouteResolve(context),
       }
     )
   }

--- a/examples/react-nested-routes/src/lowRouterReact/Router.tsx
+++ b/examples/react-nested-routes/src/lowRouterReact/Router.tsx
@@ -41,12 +41,12 @@ function LowReactRouter(props: {
     () =>
       new LowRouter(props.routes, {
         ...props.options,
-        onResolve: (ctx, response) => {
-          while (ctx) {
-            if (!ctx.parent) break
-            ctx = ctx.parent
+        onResolve: ({ response,context }) => {
+          while (context) {
+            if (!context.parent) break
+            context = context.parent
           }
-          setRouteContext(ctx)
+          setRouteContext(context)
         },
       }),
     []

--- a/packages/low-router/src/LowRouter.ts
+++ b/packages/low-router/src/LowRouter.ts
@@ -1,5 +1,5 @@
 import { createMatcher, Matcher } from "./createMatcher"
-import { Route, RouteContext, RouteParams, RouterContext, RouterOptions } from "./types"
+import { Resolve, Route, RouteContext, RouteParams, RouterContext, RouterOptions } from "./types"
 
 /**
  * LowRouter
@@ -28,7 +28,7 @@ export class LowRouter<A = any, C extends RouterContext = RouterContext> {
    */
   public async resolve(
     pathnameOrObject: string | { name: string; params: RouteParams }
-  ): Promise<A> {
+  ): Promise<Resolve<A, C>> {
     // match route
     const routeContext = this.matchRoute(
       typeof pathnameOrObject === "string"
@@ -48,11 +48,12 @@ export class LowRouter<A = any, C extends RouterContext = RouterContext> {
     this.#log("routeContext", routeContext)
 
     // resolve
+    const p = { response: undefined, context: routeContext }
     if (typeof routeContext.route?.action === "function") {
-      const actionResponse = await routeContext.route.action?.(routeContext)
-      this.#options.onResolve?.(routeContext, actionResponse)
-      return Promise.resolve(actionResponse)
+      p.response = await routeContext.route.action(routeContext)
     }
+    this.#options.onResolve?.(p)
+    return Promise.resolve(p)
   }
 
   public dispose(): void {

--- a/packages/low-router/src/types.ts
+++ b/packages/low-router/src/types.ts
@@ -20,6 +20,11 @@ export interface RouteContext<A = any, C extends RouterContext = RouterContext> 
   parent: RouteContext<A, C> | null
 }
 
+export interface Resolve<A, C> {
+  response: ActionResponse<A>
+  context: RouteContext<A, C>
+}
+
 export interface Route<A = any, C extends RouterContext = RouterContext> {
   path: string
   name?: string
@@ -31,7 +36,7 @@ export interface Route<A = any, C extends RouterContext = RouterContext> {
 export interface RouterOptions<A = any, C extends RouterContext = RouterContext> {
   base: string
   onInit: () => void
-  onResolve: (context: RouteContext<A, C>, actionResponse: ActionResponse<A>) => void
+  onResolve: ({ response, context }: Resolve<A, C>) => void
   onDispose: () => void
   onError: () => void
   matcher: Matcher

--- a/packages/low-router/tests/resolve.test.ts
+++ b/packages/low-router/tests/resolve.test.ts
@@ -15,8 +15,8 @@ describe.concurrent("resolve", () => {
         },
       ]
       const router = new LowRouter(routes)
-      const res = await router.resolve("/foo")
-      expect(res).toEqual("hello")
+      const { response, context } = await router.resolve("/foo")
+      expect(response).toEqual("hello")
       expect(mock).toHaveBeenCalledTimes(1)
 
       await router.resolve("/foo")
@@ -44,8 +44,8 @@ describe.concurrent("resolve", () => {
         },
       ]
       const router = new LowRouter(routes)
-      const res = await router.resolve("/foo")
-      expect(res).toBe("hello /foo")
+      const { response } = await router.resolve("/foo")
+      expect(response).toBe("hello /foo")
       expect(mock).toHaveBeenCalledTimes(1)
       resolve()
     })
@@ -65,9 +65,9 @@ describe.concurrent("resolve", () => {
         { path: "bar" },
       ]
       const router = new LowRouter(routes)
-      router.resolve("/bar").then((res) => {
+      router.resolve("/bar").then(({ response, context }) => {
         expect(mock).not.toHaveBeenCalled()
-        expect(res).toBe(undefined)
+        expect(response).toBe(undefined)
         resolve()
       })
     })
@@ -83,16 +83,16 @@ describe.concurrent("resolve", () => {
       ]
 
       const router = new LowRouter(routes, {
-        onResolve: (context, res) => {
+        onResolve: ({ response, context }) => {
           expect(context.pathname).toEqual("/foo")
           expect(context.base).toEqual("/")
           expect(context.params).toEqual({})
           expect(context.route.path).toEqual("/foo")
-          expect(res).toBe("action response!")
+          expect(response).toBe("action response!")
         },
       })
-      const res = await router.resolve("/foo")
-      expect(res).toBe("action response!")
+      const { response } = await router.resolve("/foo")
+      expect(response).toBe("action response!")
       resolve()
     })
   })
@@ -127,8 +127,8 @@ describe.concurrent("resolve", () => {
       ]
 
       const router = new LowRouter(routes)
-      const ctx = await router.resolve("/b")
-      expect(ctx).toBe("bbb resolve")
+      const { response, context } = await router.resolve("/b")
+      expect(response).toBe("bbb resolve")
       resolve()
     })
   })


### PR DESCRIPTION
fix #19 

`router.resolve()` and `onReslove` option return now `{response, context}` object of the matching route.

before:
```js
router.resolve("/").then((res) => {
  // res: "Hello home!"
});
```
after:
```js
router.resolve("/").then(({ response, context }) => {
  // response: "Hello home!"
  //  context: RouteContext interface
});
```

