### PR TITLE
feat: RouteContext returns relative pathname

### DIFF
--- a/.changeset/lemon-clouds-pump.md
+++ b/.changeset/lemon-clouds-pump.md
@@ -1,0 +1,21 @@
+---
+"@wbe/low-router": minor
+---
+
+RouteContext returns relativePathname
+
+RouteContext returns `relativePathname`. It's the compiled path of current router instance. 
+
+
+```ts
+export interface RouteContext<A = any, C extends RouterContext = RouterContext> {
+  pathname: string
+  params: RouteParams
+  query: QueryParams
+  hash: Hash
+  base: string
+  route: Route<A, C>
+  parent: RouteContext<A, C> | null
++ relativePathname: string
+}
+```

--- a/packages/low-router/src/LowRouter.ts
+++ b/packages/low-router/src/LowRouter.ts
@@ -101,6 +101,7 @@ export class LowRouter<A = any, C extends RouterContext = RouterContext> {
       for (let route of routes) {
         const formatRoutePath = `${base}${route.path}`.replace(/(\/)+/g, "/")
         const [isMatch, params, query, hash] = this.#matcher(formatRoutePath, pathname)
+        const relativePathname = LowRouter.compilePath(route.path)(params)
         this.#log(`'${formatRoutePath}' match with '${pathname}'?`, isMatch)
 
         const currContext = {
@@ -111,6 +112,7 @@ export class LowRouter<A = any, C extends RouterContext = RouterContext> {
           route,
           base,
           parent,
+          relativePathname,
         }
 
         if (isMatch) {
@@ -167,7 +169,7 @@ export class LowRouter<A = any, C extends RouterContext = RouterContext> {
         .replace(/:([^/?]+)(\?)?/g, (match, key) => params?.[key] ?? "")
         .replace(/(\/)+/g, "/")
       return (
-        (s.endsWith("/") ? s.slice(0, -1) : s) +
+        (s.endsWith("/") && s !== "/" ? s.slice(0, -1) : s) +
         (query ? `${query}` : "") +
         (hash ? `#${hash}` : "")
       )

--- a/packages/low-router/src/types.ts
+++ b/packages/low-router/src/types.ts
@@ -19,6 +19,7 @@ export interface RouteContext<A = any, C extends RouterContext = RouterContext> 
   base: string
   route: Route<A, C>
   parent: RouteContext<A, C> | null
+  relativePathname: string
 }
 
 export interface Resolve<A, C> {


### PR DESCRIPTION
RouteContext returns `relativePathname`. It's the compiled path of current router instance. 