### PR TITLE
feat: change local browserHistory listener params as object

### DIFF
--- a/.changeset/clever-mugs-cross.md
+++ b/.changeset/clever-mugs-cross.md
@@ -1,0 +1,19 @@
+---
+"@wbe/low-router": minor
+---
+
+change local browserHistory listener params to object
+
+Goal is to feat with the [remix history lib](https://github.com/remix-run/history/blob/dev/docs/api-reference.md#createbrowserhistory) api in order to switch to it easily, if needed.
+
+before:
+
+```ts
+history.listen((location, action) => {})
+```
+
+after:
+
+```ts
+history.listen(({ location, action }) => {})
+```

--- a/examples/compose/src/components/App.ts
+++ b/examples/compose/src/components/App.ts
@@ -27,14 +27,16 @@ export class App {
 
     // implement a history listener
     // each time the history change, the router will resolve the new location
-    const handleHistory = (location, action?): void => {
+    const handleHistory = ({ location }): void => {
       this.router.resolve(location.pathname + location.search + location.hash)
     }
     // first call to resolve the current location
     handleHistory({
-      pathname: window.location.pathname,
-      search: window.location.search,
-      hash: window.location.hash,
+      location: {
+        pathname: window.location.pathname,
+        search: window.location.search,
+        hash: window.location.hash,
+      },
     })
     // listen to history and return the unlisten function
     const unlisten = this.browserHistory.listen(handleHistory)

--- a/examples/react-nested-routes/src/lowRouterReact/Router.tsx
+++ b/examples/react-nested-routes/src/lowRouterReact/Router.tsx
@@ -41,7 +41,7 @@ function LowReactRouter(props: {
     () =>
       new LowRouter(props.routes, {
         ...props.options,
-        onResolve: ({ response,context }) => {
+        onResolve: ({ response, context }) => {
           while (context) {
             if (!context.parent) break
             context = context.parent
@@ -67,15 +67,17 @@ function LowReactRouter(props: {
 
     if (!STORE.history || !router) return
 
-    const handleHistory = (location): void => {
+    const handleHistory = ({ location, action }: { location; action? }): void => {
       // console.log(props.options.id, "handleHistory", location)
       router.resolve(location.pathname + location.search + location.hash)
     }
     // first call to resolve the current location
     handleHistory({
-      pathname: window.location.pathname,
-      search: window.location.search,
-      hash: window.location.hash,
+      location: {
+        pathname: window.location.pathname,
+        search: window.location.search,
+        hash: window.location.hash,
+      },
     })
 
     // listen to history and return the unlisten function


### PR DESCRIPTION
Goal is to feat with the [remix history lib](https://github.com/remix-run/history/blob/dev/docs/api-reference.md#createbrowserhistory) api in order to switch to it if needed.

before:
```ts
history.listen((location, action) => {});
```
after: 
```ts
history.listen(({ location, action }) => {});
```