### PR TITLE
feat: nomalize path

### DIFF
--- a/packages/low-router/src/index.ts
+++ b/packages/low-router/src/index.ts
@@ -12,5 +12,6 @@ export type {
 // utils
 export { createMatcher, pathToRegexp } from "./utils/createMatcher"
 export { compilePath } from "./utils/compilePath"
+export { normalizePath } from "./utils/normalizePath"
 export { createBrowserHistory } from "./utils/browserHistory"
 export type { CreateBrowserHistory, HistoryAPI } from "./utils/browserHistory"

--- a/packages/low-router/src/utils/normalizePath.ts
+++ b/packages/low-router/src/utils/normalizePath.ts
@@ -1,7 +1,7 @@
 export const normalizePath = (path: string): string =>
   path
     // remove multiples slashes
-    .replace(/(\/)+/g, "/")
+    ?.replace(/(https?:\/\/)|(\/)+/g, "$1$2")
     // remove trailing slash
     .replace(/\/$/, "") ||
   // add trailing slash if path is empty

--- a/packages/low-router/src/utils/normalizePath.ts
+++ b/packages/low-router/src/utils/normalizePath.ts
@@ -1,0 +1,8 @@
+export const normalizePath = (path: string): string =>
+  path
+    // remove multiples slashes
+    .replace(/(\/)+/g, "/")
+    // remove trailing slash
+    .replace(/\/$/, "") ||
+  // add trailing slash if path is empty
+  "/"

--- a/packages/low-router/tests/compilePath.test.ts
+++ b/packages/low-router/tests/compilePath.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { compilePath } from "../src/utils/compilePath"
+import { compilePath } from "../src"
 
 describe.concurrent("compile path", () => {
   it("should compile path with params", () => {

--- a/packages/low-router/tests/normalizePath.test.ts
+++ b/packages/low-router/tests/normalizePath.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+import { normalizePath } from "../src"
+
+describe.concurrent("normalize path", () => {
+  it("should normalize path format", () => {
+    expect(normalizePath("/foo///bar")).toBe("/foo/bar")
+    expect(normalizePath("/foo///bar/")).toBe("/foo/bar")
+    expect(normalizePath("/foo/bar/foo")).toBe("/foo/bar/foo")
+    expect(normalizePath("/foo/bar/foo/")).toBe("/foo/bar/foo")
+
+    expect(normalizePath("///")).toBe("/")
+    expect(normalizePath("/")).toBe("/")
+    expect(normalizePath("")).toBe("/")
+    expect(normalizePath(null)).toBe("/")
+
+    expect(normalizePath("/---test/")).toBe("/---test")
+    expect(normalizePath("---test/")).toBe("---test")
+
+    for (let protocol of ["http", "https"]) {
+      expect(normalizePath(`${protocol}://foo/bar/`)).toBe(`${protocol}://foo/bar`)
+      expect(normalizePath(`${protocol}://foo////bar/`)).toBe(`${protocol}://foo/bar`)
+    }
+  })
+})


### PR DESCRIPTION
Create normalize path helper to get a formatted and constant path format.
```ts
  path
    // remove multiples slashes
    ?.replace(/(https?:\/\/)|(\/)+/g, "$1$2")
    // remove trailing slash
    .replace(/\/$/, "") ||
  // add trailing slash if path is empty
  "/"

```

`normalizePath(path) => string` is available : `import { normalizePath } from "@wbe/low-router`