### PR TITLE
fix: Patch missing route props on _props copy

### DIFF
--- a/.changeset/sour-beans-lie.md
+++ b/.changeset/sour-beans-lie.md
@@ -1,0 +1,9 @@
+---
+"@wbe/low-router-preact": minor
+---
+
+Patch missing route props on \_props copy
+
+reference to #56
+
+In case the route didn't had a specific props object, `_props` was `undefined`, and last `route.props` of the same route was registered in `route._props` object. To avoid this behavior, we set an empty object on `props.route` if no props exist on the initial route object.

--- a/packages/low-router-preact/examples/example-preact-ssr-static-props/src/routes.ts
+++ b/packages/low-router-preact/examples/example-preact-ssr-static-props/src/routes.ts
@@ -22,9 +22,6 @@ export const routes = [
   {
     path: "/work/:id",
     name: "work",
-    props: {
-      color: "red",
-    },
     action: () => WorkPage,
     getStaticProps: async (context, locale) => {
       if (import.meta.env.SSR) {

--- a/packages/low-router-preact/src/components/Router.ts
+++ b/packages/low-router-preact/src/components/Router.ts
@@ -189,7 +189,7 @@ function LowReactRouter(props: {
 
     // save props stored on the route object before mute it
     // if it had been already saved, return it
-    context.route._props = context.route._props || context.route.props
+    context.route._props = context.route._props || context.route.props || {}
 
     // Request get static props
     // update props with saved route._props


### PR DESCRIPTION
reference to #56   

In case the route didn't had a specific props object, `_props` was `undefined`, and last `route.props` of the same route was registered in `route._props` object. To avoid this behavior, we set an empty object on `props.route` if no props exist on the initial route object.
