### PR TITLE
fix: Remove memo wrapper on Router component

### DIFF
--- a/.changeset/cool-ducks-sort.md
+++ b/.changeset/cool-ducks-sort.md
@@ -1,0 +1,5 @@
+---
+"@wbe/low-router-preact": minor
+---
+
+Remove memo wrapper on Router component

--- a/packages/low-router-preact/src/components/Router.ts
+++ b/packages/low-router-preact/src/components/Router.ts
@@ -3,7 +3,6 @@ import {
   useRef,
   createContext,
   createElement,
-  memo,
   ReactElement,
   useEffect,
   useReducer,
@@ -293,5 +292,4 @@ function LowReactRouter(props: {
   })
 }
 
-const Router = memo(LowReactRouter)
-export { Router }
+export { LowReactRouter as Router }


### PR DESCRIPTION
`memo(Router)` fix preact/signal usage that is no able to render properly on first render. 