### PR TITLE
feat: Make "compile" option available to use a custom compile function

### DIFF
--- a/packages/low-router/README.md
+++ b/packages/low-router/README.md
@@ -170,7 +170,7 @@ import { createMatcher } from "@wbe/low-router"
 const matcher = createMatcher()
 const [isMatch, routeParams, queryParams, hash] = matcher(
   "/user/1?lang=fr&cat=foo#section-2",
-  "/user/:id"
+  "/user/:id",
 )
 // isMatch: true
 // routeParams: { id: "1" }
@@ -190,9 +190,7 @@ import { LowRouter, createMatcher } from "@wbe/low-router"
 import { pathToRegexp } from "path-to-regexp"
 
 const customPathToRegexpFn = (path: string): { keys: Record<string, string>[]; regexp: RegExp } => {
-  let keys = []
-  const regexp = pathToRegexp(path, keys)
-  return { keys, regexp }
+  return pathToRegexp(path, keys)
 }
 
 const customMatcher = createMatcher(customPathToRegexpFn)

--- a/packages/low-router/examples/custom-path-to-regexp/src/index.ts
+++ b/packages/low-router/examples/custom-path-to-regexp/src/index.ts
@@ -24,23 +24,18 @@ const routes = [
 
 // we can use other path to regexp fn like the original "pathToRegexp" package
 // https://github.com/pillarjs/path-to-regexp
-import { pathToRegexp } from "path-to-regexp"
+import { compile, pathToRegexp } from "path-to-regexp"
 
-const customPathToRegexpFn = (path: string): { keys: any[]; regexp: RegExp } => {
-  let keys = []
-  const regexp = pathToRegexp(path, keys)
-  console.log({ keys, regexp })
-  return { keys, regexp }
-}
-
-const customMatcher = createMatcher(customPathToRegexpFn)
 // ex: customMatcher("/about/:id", "/about/1")
 // return: [true, { id: "1" }, {}, null]
+const customMatcher = createMatcher((path: string): { keys: any[]; regexp: RegExp } => {
+  return pathToRegexp(path)
+})
 
 /**
  * Create router
  */
-const router = new LowRouter(routes, { matcher: customMatcher })
+const router = new LowRouter(routes, { matcher: customMatcher, compile })
 
 /**
  * Listen links

--- a/packages/low-router/src/LowRouter.ts
+++ b/packages/low-router/src/LowRouter.ts
@@ -13,6 +13,7 @@ export class LowRouter {
   currentContext: RouteContext | undefined
   options: Partial<RouterOptions>
   matcher: Matcher
+  compile: RouterOptions["compile"]
 
   constructor(routes: Route[], options: Partial<RouterOptions> = {}) {
     this.routes = routes
@@ -24,6 +25,7 @@ export class LowRouter {
     this.#log("options", this.options)
 
     this.matcher = this.options.matcher || createMatcher()
+    this.compile = this.options.compile || compilePath
     this.options.onInit?.()
   }
 

--- a/packages/low-router/src/types.ts
+++ b/packages/low-router/src/types.ts
@@ -37,5 +37,6 @@ export interface RouterOptions {
   onDispose: () => void
   onError: () => void
   matcher: Matcher
+  compile: (path: string, options) => (params) => string
   id?: number | string
 }

--- a/packages/low-router/src/utils/compilePath.ts
+++ b/packages/low-router/src/utils/compilePath.ts
@@ -5,14 +5,15 @@ import { RouteParams } from "../types"
  * Naive implementation of "compile" path-to-regexp function
  *
  * ex:
- *  compilePath("/foo/:id", {id: "bar"}) -> /foo/bar
- *  compilePath("/foo/:id?", {id: "bar"}) -> /foo/bar
- *  compilePath("/foo?param=one", {id: "bar"}) -> /foo?param=one
+ *  compilePath("/foo/:id")({id: "bar"}) -> /foo/bar
+ *  compilePath("/foo/:id?")({id: "bar"}) -> /foo/bar
+ *  compilePath("/foo?param=one")({id: "bar"}) -> /foo?param=one
  * @param path
+ * @param options
  */
 
-export function compilePath(path: string): (params: RouteParams) => string {
-  return (params) => {
+export function compilePath(path: string, options?: {}): (params: RouteParams) => string {
+  return (params): string => {
     const [pathWithoutHash, hash] = path.split("#")
     const query = /\?(?!\/).+$/.exec(pathWithoutHash)?.[0]
     const pathWithoutQuery = pathWithoutHash.replace(query, "")


### PR DESCRIPTION
```ts
import { compile } from "path-to-regexp"
// pass a custom compile function to the router options
const router = new LowRouter(routes, { compile })
```