### PR TITLE
fix(low-router): fix sub router playout

### DIFF
--- a/.changeset/moody-drinks-sparkle.md
+++ b/.changeset/moody-drinks-sparkle.md
@@ -1,0 +1,9 @@
+---
+"@wbe/low-router-preact": patch
+---
+
+Fix sub-router playout transitions
+
+When navigating to a parent route handled by a sub-router (no action), the Stack component fell into the "lazy" branch waiting for a ref that would never attach, since no component is rendered. This blocked the previous route's playout animation indefinitely.
+
+The fix detects routes without an action and runs the transition immediately with null, allowing the previous route to properly play out.

--- a/packages/low-router-preact/src/components/Stack.ts
+++ b/packages/low-router-preact/src/components/Stack.ts
@@ -152,10 +152,18 @@ export function Stack({ transitions, clampRoutesRender = true, as = "div", class
         current: resolvedCurrent,
       })
     }
+  
+    // Check if the current route has an action (renders a component)
+    const currentRouteContext = state.stackRoutes?.[state.stackRoutes?.length - 1]
+    const currentRouteHasAction = !!currentRouteContext?.route?.action
 
     if (current) {
       // non-lazy: ref is already attached, run immediately
       runTransition(current)
+    } else if (!currentRouteHasAction) {
+      // Route has no action (no component to render), run transition immediately
+      // so that the previous route can still play out
+      runTransition(null as RouteRef)
     } else {
       // lazy: ref not yet attached, defer until the ref callback fires
       pendingTransitionRef.current = runTransition


### PR DESCRIPTION
When navigating to a parent route handled by a sub-router (no action), the Stack component fell into the "lazy" branch waiting for a ref that would never attach, since no component is rendered. This blocked the previous route's playout animation indefinitely.

The fix detects routes without an action and runs the transition immediately with null, allowing the previous route to properly play out.